### PR TITLE
bugfix for checking whether or not open_basedir is set

### DIFF
--- a/src/Justimmo/Api/JustimmoApi.php
+++ b/src/Justimmo/Api/JustimmoApi.php
@@ -343,7 +343,7 @@ class JustimmoApi implements JustimmoApiInterface
             CURLOPT_HTTPAUTH       => CURLAUTH_ANY,
         ) + $this->curlOptions);
 
-        if (filter_var(ini_get('open_basedir'), FILTER_VALIDATE_BOOLEAN) === false && filter_var(ini_get('safe_mode'), FILTER_VALIDATE_BOOLEAN) === false) {
+        if (!ini_get('open_basedir') && filter_var(ini_get('safe_mode'), FILTER_VALIDATE_BOOLEAN) === false) {
             $request->setOption(CURLOPT_FOLLOWLOCATION, true);
         }
 


### PR DESCRIPTION
ini_get('open_basedir') does NOT return a boolean, but the path(s) set as basedir. Therefore the filter_var call will always return false which in turn prevents using the sdk on a host with open_basedir set. Directly casting the return value to a boolean seems to be the most widespread check in use in other frameworks.