### PR TITLE
added mapping from project plans to group 'GRUNDRISS'

### DIFF
--- a/src/Justimmo/Model/Wrapper/V1/ProjectWrapper.php
+++ b/src/Justimmo/Model/Wrapper/V1/ProjectWrapper.php
@@ -43,6 +43,10 @@ class ProjectWrapper extends AbstractWrapper
             $this->mapAttachmentGroup($xml->bilder->bild, $project, 'picture');
         }
 
+        if (isset($xml->plaene) && isset($xml->plaene->bild)) {
+            $this->mapAttachmentGroup($xml->plaene->bild, $project, 'picture', 'GRUNDRISS');
+        }
+
         if (isset($xml->dokumente) && isset($xml->dokumente->dokument)) {
             $this->mapAttachmentGroup($xml->dokumente->dokument, $project, 'document');
         }


### PR DESCRIPTION
At the moment there is no way to access the plans of projects. Since the last bugfix, plans are no longer part of the normal "bilder" xml element and therefore unaccessible via the sdk.

This implementation tries to be coherent with the existing structure for realties. Therefore it adds the plans with type 'picture' in group 'GRUNDRISS'. This implementation does change the new behaviour of Project#getPictures (after the bugfix), but should return the same results, as of before the mentioned bugfix. 