### PR TITLE
Adds undevelopedAtticArea to Areas

### DIFF
--- a/src/Entity/Realty/Areas.php
+++ b/src/Entity/Realty/Areas.php
@@ -107,6 +107,12 @@ class Areas implements Entity
     private $parking;
 
     /**
+     * @var float
+     * @JUSTIMMO\Column(path="undevelopedAtticArea", type="float")
+     */
+    private $undevelopedAttic;
+
+    /**
      * @return float
      */
     public function getLiving()
@@ -233,4 +239,13 @@ class Areas implements Entity
     {
         return $this->parking;
     }
+
+    /**
+     * @return float|null
+     */
+    public function getUndevelopedAttic(): ?float
+    {
+        return $this->undevelopedAttic;
+    }
+
 }

--- a/src/Request/RealtyRequest.php
+++ b/src/Request/RealtyRequest.php
@@ -74,6 +74,8 @@ use Justimmo\Api\Entity\Realty\Type;
  * @method $this filterBySurfaceArea($value)
  * @method $this filterByFloorArea($value)
  * @method $this filterByOverallArea($value)
+ * @method $this filterByHasUndevelopedAttic($value)
+ * @method $this filterByUndevelopedAtticArea($value)
  * @method $this filterByHasGarden($value)
  * @method $this filterByHasBalcony($value)
  * @method $this filterByHasTerrace($value)
@@ -208,6 +210,8 @@ class RealtyRequest extends BaseApiRequest implements SubRequest, JoinableReques
         'floorArea',
         'surfaceArea',
         'overallArea',
+        'hasUndevelopedAttic',
+        'undevelopedAtticArea',
         'hasGarden',
         'hasBalcony',
         'hasTerrace',


### PR DESCRIPTION
Implements:
 * Areas::getUndevelopedAttic()
 * RealtyRequest::filterByHasUndevelopedAttic()
 * RealtyRequest::filterByUndevelopedAtticArea()

Related to [5286](https://github.com/justimmo/app/pull/5286)
[OTRS - 1038668 - Rohachboden + Keller](https://support.bgcc.at/otrs/index.pl?Action=AgentTicketZoom;TicketID=48189)
[JUST-367](https://app.vivifyscrum.com/boards/85555/sprint-backlog/293335/JUST-367)

