### PR TITLE
Remove Attachment::url

### DIFF
--- a/src/Entity/Attachment/Attachment.php
+++ b/src/Entity/Attachment/Attachment.php
@@ -50,12 +50,6 @@ class Attachment implements Entity
 
     /**
      * @var string
-     * @JUSTIMMO\Column(path="url", type="string")
-     */
-    private $url;
-
-    /**
-     * @var string
      * @JUSTIMMO\Column(path="type", type="string")
      */
     private $type;
@@ -105,14 +99,6 @@ class Attachment implements Entity
     /**
      * @return string
      */
-    public function getUrl()
-    {
-        return $this->url;
-    }
-
-    /**
-     * @return string
-     */
     public function getFilename()
     {
         return $this->filename;
@@ -140,18 +126,6 @@ class Attachment implements Entity
     public function getStorageKey()
     {
         return $this->storageKey;
-    }
-
-    /**
-     * Returns the url to a specific picture config (size, branding, etc...)
-     *
-     * @param string $config
-     *
-     * @return string
-     */
-    public function getUrlForConfig($config = 'orig')
-    {
-        return preg_replace("!\/(pic|video)\/(\w+)\/!", "/$1/" . $config . "/", $this->getUrl());
     }
 
     /**
@@ -224,23 +198,6 @@ class Attachment implements Entity
     public function isGroupThreeSixty()
     {
         return in_array($this->group, self::GROUP_THREE60_PICTURES);
-    }
-
-    /**
-     * @param string $config
-     *
-     * @return string|null
-     */
-    public function getVideoPosterUrl($config = 'orig')
-    {
-        if (!$this->isTypeVideo()) {
-            return null;
-        }
-
-        $videoUrl = $this->getUrlForConfig($config);
-        $posterUrlParts = explode('.', str_replace('/video/', '/pic/', $videoUrl));
-        $posterUrlParts[count($posterUrlParts)-1] = 'jpg';
-        return implode('.', $posterUrlParts);
     }
 
     public function getTenantId(): int

--- a/tests/Entity/EmployeeTest.php
+++ b/tests/Entity/EmployeeTest.php
@@ -62,8 +62,6 @@ class EmployeeTest extends EntityTestCase
         $this->assertInstanceOf(Attachment::class, $profilePic);
         $this->assertEquals('4004005', $profilePic->getId());
         $this->assertEquals('7pPkLxEDBwCVrjrEy6L3Gt.jpg', $profilePic->getStorageKey());
-        $this->assertEquals('https://files.justimmo.at/public/pic/orig/APRil3QC47.jpg', $profilePic->getUrl());
-        $this->assertEquals('https://files.justimmo.at/public/pic/small/APRil3QC47.jpg', $profilePic->getUrlForConfig('small'));
         $this->assertEmpty($profilePic->getTitle());
         $this->assertEmpty($profilePic->getDescription());
         $this->assertTrue($profilePic->isTypePicture());
@@ -83,7 +81,6 @@ class EmployeeTest extends EntityTestCase
         $this->assertInstanceOf(Attachment::class, $picture);
         $this->assertEquals('20864645', $picture->getId());
         $this->assertEquals('2EJg6tBMhjKAb8KOlSbaGl.jpg', $picture->getStorageKey());
-        $this->assertEquals('https://files.justimmo.at/public/pic/orig/BPl6F4-4pB.jpg', $picture->getUrl());
         $this->assertEquals('Wolf', $picture->getTitle());
         $this->assertEquals('weiss', $picture->getDescription());
         $this->assertEquals('pictures-1.jpeg', $picture->getFilename());

--- a/tests/fixtures/entity/employee.json
+++ b/tests/fixtures/entity/employee.json
@@ -17,7 +17,6 @@
     },
     "profilePicture": {
         "id": "4004005",
-        "url": "https:\/\/files.justimmo.at\/public\/pic\/orig\/APRil3QC47.jpg",
         "type": "pic",
         "filename": "AN46eqAeNU.jpg",
         "storageKey": "7pPkLxEDBwCVrjrEy6L3Gt.jpg",
@@ -27,7 +26,6 @@
     "pictures": [
         {
             "id": "20864645",
-            "url": "https:\/\/files.justimmo.at\/public\/pic\/orig\/BPl6F4-4pB.jpg",
             "type": "pic",
             "filename": "pictures-1.jpeg",
             "storageKey": "2EJg6tBMhjKAb8KOlSbaGl.jpg",


### PR DESCRIPTION
The URL is not needed anymore, b/c it is now created with UrlFactories based on the storage key in the websites project.

Refs JI-259