### PR TITLE
Extends realty object with some areas that are already supported in API v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.2.6
+ * Extends Realty object with
+   * SalesArea (Verkaufsfläche)
+   * HallHeight (Hallenhöhe)
+   * TemporaryArea (Befristete Fläche)
+   * WeightedArea (Gewichtete Fläche)
+   * RawAtticArea (Rohdachbodenfläche)
+ * Bugfix
+   * Fixing RentDurationType to support unlimited (unbefristet) renting period
+
 ## 1.2.5
  * Add support for picturesize parameter in employee calls
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
  * Extends Realty object with
    * SalesArea (Verkaufsfläche)
    * HallHeight (Hallenhöhe)
-   * TemporaryArea (Befristete Fläche)
+   * ShortTermArea (Befristete Fläche)
    * WeightedArea (Gewichtete Fläche)
-   * RawAtticArea (Rohdachbodenfläche)
+   * UndevelopedAtticArea (Rohdachbodenfläche)
  * Bugfix
    * Fixing RentDurationType to support unlimited (unbefristet) renting period
 

--- a/src/Justimmo/Model/Mapper/V1/RealtyMapper.php
+++ b/src/Justimmo/Model/Mapper/V1/RealtyMapper.php
@@ -108,6 +108,22 @@ class RealtyMapper extends AbstractMapper
                 'property' => 'buildableArea',
                 'type'     => 'double',
             ),
+            'verkaufsflaeche'                  => array(
+                'property' => 'salesArea',
+                'type'     => 'double',
+            ),
+            'befristete_flaeche'               => array(
+                'property' => 'temporaryArea',
+                'type'     => 'double',
+            ),
+            'gewichtete_flaeche'               => array(
+                'property' => 'weightedArea',
+                'type'     => 'double',
+            ),
+            'rohdachboden_flaeche'             => array(
+                'property' => 'rawAtticArea',
+                'type'     => 'double',
+            ),
             'wohnflaeche'                      => array(
                 'property' => 'livingArea',
                 'type'     => 'double',
@@ -302,6 +318,10 @@ class RealtyMapper extends AbstractMapper
             ),
             'raumhoehe'                        => array(
                 'property' => 'ceilingHeight',
+                'type'     => 'double',
+            ),
+            'hallenhoehe'                      => array(
+                'property' => 'hallHeight',
                 'type'     => 'double',
             ),
             'epass_hwbwert'                    => array(

--- a/src/Justimmo/Model/Mapper/V1/RealtyMapper.php
+++ b/src/Justimmo/Model/Mapper/V1/RealtyMapper.php
@@ -113,7 +113,7 @@ class RealtyMapper extends AbstractMapper
                 'type'     => 'double',
             ),
             'befristete_flaeche'               => array(
-                'property' => 'temporaryArea',
+                'property' => 'shortTermArea',
                 'type'     => 'double',
             ),
             'gewichtete_flaeche'               => array(
@@ -121,7 +121,7 @@ class RealtyMapper extends AbstractMapper
                 'type'     => 'double',
             ),
             'rohdachboden_flaeche'             => array(
-                'property' => 'rawAtticArea',
+                'property' => 'undevelopedAtticArea',
                 'type'     => 'double',
             ),
             'wohnflaeche'                      => array(

--- a/src/Justimmo/Model/Realty.php
+++ b/src/Justimmo/Model/Realty.php
@@ -110,7 +110,7 @@ class Realty
     /**
      * @var float|null
      */
-    protected $temporaryArea;
+    protected $shortTermArea;
 
     /**
      * @var float|null
@@ -120,7 +120,7 @@ class Realty
     /**
      * @var float|null
      */
-    protected $rawAtticArea;
+    protected $undevelopedAtticArea;
 
     /**
      * @var int
@@ -1854,18 +1854,18 @@ class Realty
     /**
      * @return float|null
      */
-    public function getTemporaryArea()
+    public function getShortTermArea()
     {
-        return $this->temporaryArea;
+        return $this->shortTermArea;
     }
 
     /**
-     * @param float|null $temporaryArea
+     * @param float|null $shortTermArea
      * @return $this
      */
-    public function setTemporaryArea($temporaryArea)
+    public function setShortTermArea($shortTermArea)
     {
-        $this->temporaryArea = $temporaryArea;
+        $this->shortTermArea = $shortTermArea;
 
         return $this;
     }
@@ -1892,18 +1892,18 @@ class Realty
     /**
      * @return float|null
      */
-    public function getRawAtticArea()
+    public function getUndevelopedAtticArea()
     {
-        return $this->rawAtticArea;
+        return $this->undevelopedAtticArea;
     }
 
     /**
-     * @param float|null $rawAtticArea
+     * @param float|null $undevelopedAtticArea
      * @return $this
      */
-    public function setRawAtticArea($rawAtticArea)
+    public function setUndevelopedAtticArea($undevelopedAtticArea)
     {
-        $this->rawAtticArea = $rawAtticArea;
+        $this->undevelopedAtticArea = $undevelopedAtticArea;
 
         return $this;
     }

--- a/src/Justimmo/Model/Realty.php
+++ b/src/Justimmo/Model/Realty.php
@@ -103,6 +103,26 @@ class Realty
     protected $totalArea;
 
     /**
+     * @var float|null
+     */
+    protected $salesArea;
+
+    /**
+     * @var float|null
+     */
+    protected $temporaryArea;
+
+    /**
+     * @var float|null
+     */
+    protected $weightedArea;
+
+    /**
+     * @var float|null
+     */
+    protected $rawAtticArea;
+
+    /**
      * @var int
      */
     protected $projectId;
@@ -294,6 +314,10 @@ class Realty
     protected $storeRoomCount;
 
     protected $ceilingHeight;
+    /**
+     * @var float|null
+     */
+    protected $hallHeight;
 
     protected $contractEstablishmentCosts;
 
@@ -1809,6 +1833,82 @@ class Realty
     }
 
     /**
+     * @return float|null
+     */
+    public function getSalesArea()
+    {
+        return $this->salesArea;
+    }
+
+    /**
+     * @param float|null $salesArea
+     * @return $this
+     */
+    public function setSalesArea($salesArea)
+    {
+        $this->salesArea = $salesArea;
+
+        return $this;
+    }
+
+    /**
+     * @return float|null
+     */
+    public function getTemporaryArea()
+    {
+        return $this->temporaryArea;
+    }
+
+    /**
+     * @param float|null $temporaryArea
+     * @return $this
+     */
+    public function setTemporaryArea($temporaryArea)
+    {
+        $this->temporaryArea = $temporaryArea;
+
+        return $this;
+    }
+
+    /**
+     * @return float|null
+     */
+    public function getWeightedArea()
+    {
+        return $this->weightedArea;
+    }
+
+    /**
+     * @param float|null $weightedArea
+     * @return $this
+     */
+    public function setWeightedArea($weightedArea)
+    {
+        $this->weightedArea = $weightedArea;
+
+        return $this;
+    }
+
+    /**
+     * @return float|null
+     */
+    public function getRawAtticArea()
+    {
+        return $this->rawAtticArea;
+    }
+
+    /**
+     * @param float|null $rawAtticArea
+     * @return $this
+     */
+    public function setRawAtticArea($rawAtticArea)
+    {
+        $this->rawAtticArea = $rawAtticArea;
+
+        return $this;
+    }
+
+    /**
      * @param float $wohnflaeche
      *
      * @return $this
@@ -1999,6 +2099,25 @@ class Realty
     public function getCeilingHeight()
     {
         return $this->ceilingHeight;
+    }
+
+    /**
+     * @param float|null $hallHeight
+     * @return $this;
+     */
+    public function setHallHeight($hallHeight)
+    {
+        $this->hallHeight = $hallHeight;
+
+        return $this;
+    }
+
+    /**
+     * @return float|null
+     */
+    public function getHallHeight()
+    {
+        return $this->hallHeight;
     }
 
     /**

--- a/tests/Fixtures/v1/realty_detail_2.xml
+++ b/tests/Fixtures/v1/realty_detail_2.xml
@@ -176,16 +176,11 @@
             <teilbar_ab>20</teilbar_ab>
             <grundstuecksflaeche>150</grundstuecksflaeche>
             <verbaubare_flaeche>355</verbaubare_flaeche>
-            <verkaufsflaeche>377</verkaufsflaeche>
             <anzahl_garagen>1</anzahl_garagen>
             <garagen_flaeche>20.57</garagen_flaeche>
             <anzahl_stellplaetze>2</anzahl_stellplaetze>
             <stellplatz_flaeche>36.85</stellplatz_flaeche>
             <raumhoehe>3.5</raumhoehe>
-            <user_defined_simplefield feldname="befristete_flaeche">113</user_defined_simplefield>
-            <user_defined_simplefield feldname="gewichtete_flaeche">115</user_defined_simplefield>
-            <user_defined_simplefield feldname="rohdachboden_flaeche">117</user_defined_simplefield>
-            <user_defined_simplefield feldname="hallenhoehe">3.25</user_defined_simplefield>
         </flaechen>
         <ausstattung>
             <ausricht_balkon_terrasse NORD="1"/>
@@ -397,7 +392,7 @@
             <verfuegbar_ab>November 2015</verfuegbar_ab>
             <status>aktiv</status>
             <status_id>5</status_id>
-            <max_mietdauer max_dauer="MONAT">5</max_mietdauer>
+            <max_mietdauer>unbefristet</max_mietdauer>
             <user_defined_simplefield feldname="ji_objektstatus">aktiv</user_defined_simplefield>
             <user_defined_simplefield feldname="ji_objektstatus_id">5</user_defined_simplefield>
             <user_defined_simplefield feldname="vermittelt_am">2015-11-11</user_defined_simplefield>

--- a/tests/Justimmo/Tests/Wrapper/V1/RealtyWrapperTest.php
+++ b/tests/Justimmo/Tests/Wrapper/V1/RealtyWrapperTest.php
@@ -142,11 +142,16 @@ class RealtyWrapperTest extends TestCase
         $this->assertEquals($objekt->getSurfaceArea(), 150);
         $this->assertNull($objekt->getLivingArea());
         $this->assertNull($objekt->getTotalArea());
+        $this->assertEquals(377, $objekt->getSalesArea());
+        $this->assertEquals(113, $objekt->getTemporaryArea());
+        $this->assertEquals(115, $objekt->getWeightedArea());
+        $this->assertEquals(117, $objekt->getRawAtticArea());
         $this->assertEquals($objekt->getGarageCount(), 1);
         $this->assertEquals($objekt->getGarageArea(), 20.57);
         $this->assertEquals($objekt->getParkingCount(), 2);
         $this->assertEquals($objekt->getParkingArea(), 36.85);
         $this->assertEquals($objekt->getCeilingHeight(), 3.5);
+        $this->assertEquals(3.25, $objekt->getHallHeight());
 
         $this->assertEquals(450000, $objekt->getPurchasePrice());
         $this->assertEquals(3000, $objekt->getPurchasePricePerSqm());
@@ -368,4 +373,23 @@ class RealtyWrapperTest extends TestCase
 
         $this->assertEquals(2, $objekt->getOwnershipTypeId());
     }
+
+    public function testTransformSingleNullValuesAndUnlimitedRent()
+    {
+        /** @var \Justimmo\Model\Realty $objekt */
+        $objekt = $this->wrapper->transformSingle($this->getFixtures('v1/realty_detail_2.xml'));
+
+        $this->assertInstanceOf('\Justimmo\Model\Realty', $objekt);
+
+        $this->assertNull($objekt->getSalesArea());
+        $this->assertNull($objekt->getTemporaryArea());
+        $this->assertNull($objekt->getWeightedArea());
+        $this->assertNull($objekt->getRawAtticArea());
+
+        $this->assertNull($objekt->getHallHeight());
+
+        $this->assertEquals(0, $objekt->getRentDuration());
+        $this->assertEquals('unlimited', $objekt->getRentDurationType());
+    }
+
 }

--- a/tests/Justimmo/Tests/Wrapper/V1/RealtyWrapperTest.php
+++ b/tests/Justimmo/Tests/Wrapper/V1/RealtyWrapperTest.php
@@ -143,9 +143,9 @@ class RealtyWrapperTest extends TestCase
         $this->assertNull($objekt->getLivingArea());
         $this->assertNull($objekt->getTotalArea());
         $this->assertEquals(377, $objekt->getSalesArea());
-        $this->assertEquals(113, $objekt->getTemporaryArea());
+        $this->assertEquals(113, $objekt->getShortTermArea());
         $this->assertEquals(115, $objekt->getWeightedArea());
-        $this->assertEquals(117, $objekt->getRawAtticArea());
+        $this->assertEquals(117, $objekt->getUndevelopedAtticArea());
         $this->assertEquals($objekt->getGarageCount(), 1);
         $this->assertEquals($objekt->getGarageArea(), 20.57);
         $this->assertEquals($objekt->getParkingCount(), 2);
@@ -382,9 +382,9 @@ class RealtyWrapperTest extends TestCase
         $this->assertInstanceOf('\Justimmo\Model\Realty', $objekt);
 
         $this->assertNull($objekt->getSalesArea());
-        $this->assertNull($objekt->getTemporaryArea());
+        $this->assertNull($objekt->getShortTermArea());
         $this->assertNull($objekt->getWeightedArea());
-        $this->assertNull($objekt->getRawAtticArea());
+        $this->assertNull($objekt->getUndevelopedAtticArea());
 
         $this->assertNull($objekt->getHallHeight());
 


### PR DESCRIPTION
 * Extends Realty object with
   * SalesArea (Verkaufsfläche)
   * TemporaryArea (Befristete Fläche)
   * WeightedArea (Gewichtete Fläche)
   * RawAtticArea (Rohdachbodenfläche)
   * HallHeight (Hallenhöhe)
 * Bugfix
   * Fixing RentDurationType to support unlimited (unbefristet) renting period

Refs: JI-1352, justimmo/php-sdk#153


**Deployment:**
 * add new version: 1.2.6