### PR TITLE
Extends findPk method in abstract query for project queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.7
+ * Extends findPk method in abstract query for project queries
+   * it needs to accept the parameter `alleProjektObjekte` to be able to list sub real-estates of a given project with status STATUS_PROCURED (8) and STATUS_EXTERNAL_PROCURED (10)
+
 ## 1.2.6
  * Extends Realty object with
    * SalesArea (Verkaufsfläche)

--- a/src/Justimmo/Model/Query/AbstractQuery.php
+++ b/src/Justimmo/Model/Query/AbstractQuery.php
@@ -149,6 +149,9 @@ abstract class AbstractQuery implements QueryInterface
         if (isset($this->params['picturesize'])) {
             $params['picturesize'] = $this->params['picturesize'];
         }
+        if (isset($this->params['alleProjektObjekte'])) {
+            $params['alleProjektObjekte'] = $this->params['alleProjektObjekte'];
+        }
 
         $method   = $this->getDetailCall();
         $response = $this->api->$method($pk, $params);


### PR DESCRIPTION
 * it needs to accept the parameter `alleProjektObjekte` to be able to list sub real-estates with status STATUS_PROCURED (8) and STATUS_EXTERNAL_PROCURED (10)

Refs: https://support.bgcc.at/otrs/index.pl?Action=AgentTicketZoom;TicketID=61195

Deploy:
 * new release: 1.2.7