### PR TITLE
Fixes Attachment initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.8
+ * Bugfix
+   * Fixes a bug that picture size "orig" in Attachment::getData() would be overwritten by another size under certain circumstances
+
 ## 1.2.7
  * Extends findPk method in abstract query for project queries
    * it needs to accept the parameter `alleProjektObjekte` to be able to list sub real-estates of a given project with status STATUS_PROCURED (8) and STATUS_EXTERNAL_PROCURED (10)

--- a/src/Justimmo/Model/Attachment.php
+++ b/src/Justimmo/Model/Attachment.php
@@ -69,8 +69,8 @@ class Attachment
     }
 
     /**
-     * gets a url to an attachment size, even if the api does not return that size.
-     * BEWARE: this method cannot ensure that the url is a valid ressource
+     * gets an url to an attachment size, even if the api does not return that size.
+     * BEWARE: this method cannot ensure that the url is a valid resource
      *
      * @param string $size
      *

--- a/src/Justimmo/Model/Wrapper/V1/AbstractWrapper.php
+++ b/src/Justimmo/Model/Wrapper/V1/AbstractWrapper.php
@@ -94,7 +94,8 @@ abstract class AbstractWrapper implements WrapperInterface
             $attributes = $this->attributesToArray($anhang);
             $group = $forceGroup ?: (array_key_exists('gruppe', $attributes) ? $attributes['gruppe'] : null);
             if (array_key_exists('pfad', $data)) {
-                $attachment = new Attachment($data['pfad'], $type, $group);
+                $path = isset($data['orig']) ? $data['orig'] : $data['pfad'];
+                $attachment = new Attachment($path, $type, $group);
                 $attachment->mergeData($data);
                 if (isset($anhang->vorschaubild)) {
                     $attachment->mergeData(array('vorschaubild' => $this->cast($anhang->vorschaubild)));
@@ -106,7 +107,8 @@ abstract class AbstractWrapper implements WrapperInterface
                 if (isset($anhang->gruppe)) {
                     $group = strtoupper($this->cast($anhang->gruppe));
                 }
-                $attachment = new Attachment($this->cast($anhang->pfad), $type, $group);
+                $path = isset($anhang->orig) ? $anhang->orig : $anhang->pfad;
+                $attachment = new Attachment($this->cast($path), $type, $group);
                 if (isset($anhang->vorschaubild)) {
                     $attachment->mergeData(array('vorschaubild' => $this->cast($anhang->vorschaubild)));
                 }

--- a/src/Justimmo/Model/Wrapper/V1/EmployeeWrapper.php
+++ b/src/Justimmo/Model/Wrapper/V1/EmployeeWrapper.php
@@ -124,7 +124,7 @@ class EmployeeWrapper extends AbstractWrapper
             if (array_key_exists('pfad', $data)) {
                 $data['big'] = $data['pfad'];
 
-                $attachment = new Attachment($data['orig'] ?? $data['pfad'], $type, $group);
+                $attachment = new Attachment(isset($data['orig']) ? $data['orig'] : $data['pfad'], $type, $group);
                 $attachment->mergeData($data);
                 if (isset($anhang->vorschaubild)) {
                     $attachment->mergeData(array('vorschaubild' => $this->cast($anhang->vorschaubild)));

--- a/tests/Fixtures/v1/realty_detail_2.xml
+++ b/tests/Fixtures/v1/realty_detail_2.xml
@@ -242,6 +242,7 @@
                 <anhangtitel/>
                 <format>.jpg</format>
                 <daten>
+                    <orig>http://files.justimmo.at/public/AHA0s6aAaT.jpg</orig>
                     <pfad>http://files.justimmo.at/public/pic/big/AHA0s6aAaT.jpg</pfad>
                     <small>http://files.justimmo.at/public/pic/small/AHA0s6aAaT.jpg</small>
                     <medium>http://files.justimmo.at/public/pic/medium/AHA0s6aAaT.jpg</medium>
@@ -254,6 +255,7 @@
                 <anhangtitel/>
                 <format>.jpg</format>
                 <daten>
+                    <orig>http://files.justimmo.at/public/AH9qz2UD9N.jpg</orig>
                     <pfad>http://files.justimmo.at/public/pic/big/AH9qz2UD9N.jpg</pfad>
                     <small>http://files.justimmo.at/public/pic/small/AH9qz2UD9N.jpg</small>
                     <medium>http://files.justimmo.at/public/pic/medium/AH9qz2UD9N.jpg</medium>
@@ -266,6 +268,7 @@
                 <anhangtitel/>
                 <format>.jpg</format>
                 <daten>
+                    <orig>http://files.justimmo.at/public/AKTkdL-vUO.jpg</orig>
                     <pfad>http://files.justimmo.at/public/pic/big/AKTkdL-vUO.jpg</pfad>
                     <small>http://files.justimmo.at/public/pic/small/AKTkdL-vUO.jpg</small>
                     <medium>http://files.justimmo.at/public/pic/medium/AKTkdL-vUO.jpg</medium>
@@ -278,6 +281,7 @@
                 <anhangtitel/>
                 <format>.jpg</format>
                 <daten>
+                    <orig>http://files.justimmo.at/public/AH6hJRzdDi.jpg</orig>
                     <pfad>http://files.justimmo.at/public/pic/big/AH6hJRzdDi.jpg</pfad>
                     <small>http://files.justimmo.at/public/pic/small/AH6hJRzdDi.jpg</small>
                     <medium>http://files.justimmo.at/public/pic/medium/AH6hJRzdDi.jpg</medium>
@@ -290,6 +294,7 @@
                 <anhangtitel/>
                 <format>.jpg</format>
                 <daten>
+                    <orig>http://files.justimmo.at/public/AH6hKKOUe_.jpg</orig>
                     <pfad>http://files.justimmo.at/public/pic/big/AH6hKKOUe_.jpg</pfad>
                     <small>http://files.justimmo.at/public/pic/small/AH6hKKOUe_.jpg</small>
                     <medium>http://files.justimmo.at/public/pic/medium/AH6hKKOUe_.jpg</medium>
@@ -302,6 +307,7 @@
                 <anhangtitel/>
                 <format>.jpg</format>
                 <daten>
+                    <orig>http://files.justimmo.at/public/AKTkxv_wOI.jpg</orig>
                     <pfad>http://files.justimmo.at/public/pic/big/AKTkxv_wOI.jpg</pfad>
                     <small>http://files.justimmo.at/public/pic/small/AKTkxv_wOI.jpg</small>
                     <medium>http://files.justimmo.at/public/pic/medium/AKTkxv_wOI.jpg</medium>
@@ -314,6 +320,7 @@
                 <anhangtitel/>
                 <format>.jpg</format>
                 <daten>
+                    <orig>http://files.justimmo.at/public/AKTkVwkOAX.jpg</orig>
                     <pfad>http://files.justimmo.at/public/pic/big/AKTkVwkOAX.jpg</pfad>
                     <small>http://files.justimmo.at/public/pic/small/AKTkVwkOAX.jpg</small>
                     <medium>http://files.justimmo.at/public/pic/medium/AKTkVwkOAX.jpg</medium>
@@ -326,6 +333,7 @@
                 <anhangtitel/>
                 <format>.jpg</format>
                 <daten>
+                    <orig>http://files.justimmo.at/public/AHA0vHltyk.jpg</orig>
                     <pfad>http://files.justimmo.at/public/pic/big/AHA0vHltyk.jpg</pfad>
                     <small>http://files.justimmo.at/public/pic/small/AHA0vHltyk.jpg</small>
                     <medium>http://files.justimmo.at/public/pic/medium/AHA0vHltyk.jpg</medium>
@@ -338,6 +346,7 @@
                 <anhangtitel/>
                 <format>.jpg</format>
                 <daten>
+                    <orig>http://files.justimmo.at/public/AH6hLIiZe5.jpg</orig>
                     <pfad>http://files.justimmo.at/public/pic/big/AH6hLIiZe5.jpg</pfad>
                     <small>http://files.justimmo.at/public/pic/small/AH6hLIiZe5.jpg</small>
                     <medium>http://files.justimmo.at/public/pic/medium/AH6hLIiZe5.jpg</medium>
@@ -350,6 +359,7 @@
                 <anhangtitel/>
                 <format>.jpg</format>
                 <daten>
+                    <orig>http://files.justimmo.at/public/AHA0ubVAFQ.jpg</orig>
                     <pfad>http://files.justimmo.at/public/pic/big/AHA0ubVAFQ.jpg</pfad>
                     <small>http://files.justimmo.at/public/pic/small/AHA0ubVAFQ.jpg</small>
                     <medium>http://files.justimmo.at/public/pic/medium/AHA0ubVAFQ.jpg</medium>
@@ -362,6 +372,7 @@
                 <anhangtitel/>
                 <format>.jpg</format>
                 <daten>
+                    <orig>http://files.justimmo.at/public/ANl3XFL2ar.jpg</orig>
                     <pfad>http://files.justimmo.at/public/pic/big/ANl3XFL2ar.jpg</pfad>
                     <small>http://files.justimmo.at/public/pic/small/ANl3XFL2ar.jpg</small>
                     <medium>http://files.justimmo.at/public/pic/medium/ANl3XFL2ar.jpg</medium>

--- a/tests/Justimmo/Tests/Wrapper/V1/RealtyWrapperAttachmentGroupTest.php
+++ b/tests/Justimmo/Tests/Wrapper/V1/RealtyWrapperAttachmentGroupTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace Justimmo\Tests\Wrapper\V1;
+
+use Justimmo\Model\Attachment;
+use Justimmo\Model\Mapper\V1\RealtyMapper;
+use Justimmo\Model\Wrapper\V1\RealtyWrapper;
+use Justimmo\Tests\TestCase;
+
+/**
+ * @covers AbstractWrapper::mapAttachmentGroup
+ */
+class RealtyWrapperAttachmentGroupTest extends TestCase
+{
+    public function testWithoutOrig()
+    {
+        $wrapper = new RealtyWrapper(new RealtyMapper());
+
+        $response = $this->getFixtures('v1/realty_detail.xml');
+        $realty   = $wrapper->transformSingle($response);
+
+        $attachments = $realty->getAttachments();
+        /** @var Attachment $attachment */
+        foreach ($attachments as $attachment) {
+            if ($attachment->getGroup() === 'LINKS') {
+                continue;
+            }
+
+            $data = $attachment->getData();
+            $this->assertEquals('/public/pic/big', dirname(parse_url($data['orig'])['path']));
+            $this->assertEquals('/public/pic/big', dirname(parse_url($data['pfad'])['path']));
+            $this->assertEquals('/public/pic/small', dirname(parse_url($data['small'])['path']));
+            $this->assertEquals('/public/pic/medium', dirname(parse_url($data['medium'])['path']));
+            $this->assertEquals('/public/pic/big2', dirname(parse_url($data['big2'])['path']));
+            $this->assertEquals('/public/pic/pdf', dirname(parse_url($data['medium2'])['path']));
+            $this->assertEquals('/public/pic/s220x155', dirname(parse_url($data['s220x155'])['path']));
+        }
+    }
+
+    public function testWithOrig()
+    {
+        $wrapper = new RealtyWrapper(new RealtyMapper());
+
+        $response = $this->getFixtures('v1/realty_detail_2.xml');
+        $realty   = $wrapper->transformSingle($response);
+
+        $attachments = $realty->getAttachments();
+        /** @var Attachment $attachment */
+        foreach ($attachments as $attachment) {
+            if ($attachment->getGroup() === 'LINKS') {
+                continue;
+            }
+
+            $data = $attachment->getData();
+            $this->assertEquals('/public', dirname(parse_url($data['orig'])['path']));
+            $this->assertEquals('/public/pic/big', dirname(parse_url($data['pfad'])['path']));
+            $this->assertEquals('/public/pic/small', dirname(parse_url($data['small'])['path']));
+            $this->assertEquals('/public/pic/medium', dirname(parse_url($data['medium'])['path']));
+            $this->assertEquals('/public/pic/big2', dirname(parse_url($data['big2'])['path']));
+            $this->assertEquals('/public/pic/pdf', dirname(parse_url($data['medium2'])['path']));
+            $this->assertEquals('/public/pic/s220x155', dirname(parse_url($data['s220x155'])['path']));
+        }
+    }
+
+}


### PR DESCRIPTION
 * Attachment is initialized by orig (if available) instead of pfad
 * new test: AbstractWrapper::mapAttachmentGroup()

Refs: https://support.bgcc.at/otrs/index.pl?Action=AgentTicketZoom;TicketID=61216