### PR TITLE
[FIX] Add webp as pictureExtensions

### DIFF
--- a/src/Justimmo/Model/Attachment.php
+++ b/src/Justimmo/Model/Attachment.php
@@ -15,7 +15,7 @@ class Attachment
     private   $newStorageHost   = 'storage.justimmo.at';
     private   $canConvertUrl    = true;
 
-    protected static $pictureExtensions = array('jpg', 'gif', 'png', 'jpeg');
+    protected static $pictureExtensions = array('jpg', 'gif', 'png', 'jpeg', 'webp');
     protected static $videoExtensions = array('avi', 'mp4', 'mpg', 'wmv');
     protected static $linkGroups = array('LINKS', 'FILMLINK', 'RUNDGANG', 'PROJEKTURL');
 


### PR DESCRIPTION
When users add webp images in justimmo, they are not accessible via getPictures() because the extension is not recognized as an image. This change should fix the issue.