### PR TITLE
Fix php 8.5 deprecations, whitespace in text nodes, and two missing contact fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+* Replace deprecated `(double)` casts with `(float)` — every parsed response raised E_DEPRECATED on php 8.5
+* Trim whitespace from text nodes, so attachment urls from pretty printed responses are valid urls
+* `Attachment.getUrl` throws `AttachmentSizeNotFoundException` for a size the api did not return, instead of emitting a php warning and returning null
+* Map the contact person's `firma` and `land` to `Employee.company` and `Employee.country`
+
 ## 1.3.0
 * Add support for political districts
   * BasicDataQuery.findPoliticalDistricts

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -739,18 +739,6 @@ parameters:
 			path: src/Justimmo/Model/Attachment.php
 
 		-
-			message: '#^Method Justimmo\\Model\\Attachment\:\:getUrl\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Justimmo/Model/Attachment.php
-
-		-
-			message: '#^Method Justimmo\\Model\\Attachment\:\:getUrl\(\) has parameter \$size with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Justimmo/Model/Attachment.php
-
-		-
 			message: '#^Method Justimmo\\Model\\Attachment\:\:mergeData\(\) has parameter \$data with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/Justimmo/Model/Attachment.php
+++ b/src/Justimmo/Model/Attachment.php
@@ -64,8 +64,24 @@ class Attachment
         return true;
     }
 
+    /**
+     * gets the url of an attachment size as returned by the api
+     *
+     * @param string $size
+     *
+     * @return string
+     * @throws AttachmentSizeNotFoundException if the api did not return the requested size
+     */
     public function getUrl($size = 'orig')
     {
+        if (!array_key_exists($size, $this->data)) {
+            throw new AttachmentSizeNotFoundException(sprintf(
+                'The attachment does not provide the size "%s". Available sizes: %s. Use calculateUrl() to derive an url for a size the api did not return.',
+                $size,
+                count($this->data) > 0 ? implode(', ', array_keys($this->data)) : 'none'
+            ));
+        }
+
         return $this->data[$size];
     }
 

--- a/src/Justimmo/Model/Employee.php
+++ b/src/Justimmo/Model/Employee.php
@@ -100,6 +100,16 @@ class Employee
     protected $salutation = null;
 
     /**
+     * @var null|string
+     */
+    protected $company = null;
+
+    /**
+     * @var null|string
+     */
+    protected $country = null;
+
+    /**
      * @param array $attachments
      *
      * @return $this
@@ -537,5 +547,47 @@ class Employee
     public function setSalutation($salutation)
     {
         $this->salutation = $salutation;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getCompany()
+    {
+        return $this->company;
+    }
+
+    /**
+     * @param null|string $company
+     *
+     * @return $this
+     */
+    public function setCompany($company)
+    {
+        $this->company = $company;
+
+        return $this;
+    }
+
+    /**
+     * the iso 3166-1 alpha-3 country code, e.g. AUT
+     *
+     * @return null|string
+     */
+    public function getCountry()
+    {
+        return $this->country;
+    }
+
+    /**
+     * @param null|string $country
+     *
+     * @return $this
+     */
+    public function setCountry($country)
+    {
+        $this->country = $country;
+
+        return $this;
     }
 }

--- a/src/Justimmo/Model/Mapper/V1/EmployeeMapper.php
+++ b/src/Justimmo/Model/Mapper/V1/EmployeeMapper.php
@@ -66,6 +66,9 @@ class EmployeeMapper extends AbstractMapper
             'anrede'         => array(
                 'property' => 'salutation',
             ),
+            'firma'          => array(
+                'property' => 'company',
+            ),
         );
     }
 

--- a/src/Justimmo/Model/Wrapper/V1/AbstractWrapper.php
+++ b/src/Justimmo/Model/Wrapper/V1/AbstractWrapper.php
@@ -47,15 +47,15 @@ abstract class AbstractWrapper implements WrapperInterface
     {
         switch ($type) {
             case 'string':
-                return (string) $xml;
+                return trim((string) $xml);
             case 'int':
                 return (int) $xml;
             case 'double':
                 return (float) $xml;
             case 'boolean' :
-                return (bool) ((string) $xml);
+                return (bool) trim((string) $xml);
             case 'datetime':
-                $date = (string) $xml;
+                $date = trim((string) $xml);
                 if (empty($date)) {
                     return null;
                 }
@@ -63,6 +63,29 @@ abstract class AbstractWrapper implements WrapperInterface
             default:
                 return $xml;
         }
+    }
+
+    /**
+     * trims the string values of an array
+     *
+     * The api pretty prints some responses, which puts the value of an element
+     * on its own indented line. The resulting whitespace is part of the text
+     * node, so an url read straight out of the array fails
+     * filter_var(..., FILTER_VALIDATE_URL).
+     *
+     * @param array $values
+     *
+     * @return array
+     */
+    protected function trimValues(array $values)
+    {
+        foreach ($values as $key => $value) {
+            if (is_string($value)) {
+                $values[$key] = trim($value);
+            }
+        }
+
+        return $values;
     }
 
     /**
@@ -90,7 +113,7 @@ abstract class AbstractWrapper implements WrapperInterface
     protected function mapAttachmentGroup(\SimpleXMLElement $xml, $attachmentAware, $type = null, $forceGroup = null)
     {
         foreach ($xml as $anhang) {
-            $data = (array) $anhang->daten;
+            $data = $this->trimValues((array) $anhang->daten);
             $attributes = $this->attributesToArray($anhang);
             $group = $forceGroup ?: (array_key_exists('gruppe', $attributes) ? $attributes['gruppe'] : null);
             if (array_key_exists('pfad', $data)) {

--- a/src/Justimmo/Model/Wrapper/V1/AbstractWrapper.php
+++ b/src/Justimmo/Model/Wrapper/V1/AbstractWrapper.php
@@ -73,9 +73,9 @@ abstract class AbstractWrapper implements WrapperInterface
      * node, so an url read straight out of the array fails
      * filter_var(..., FILTER_VALIDATE_URL).
      *
-     * @param array $values
+     * @param array<string, mixed> $values
      *
-     * @return array
+     * @return array<string, mixed>
      */
     protected function trimValues(array $values)
     {

--- a/src/Justimmo/Model/Wrapper/V1/AbstractWrapper.php
+++ b/src/Justimmo/Model/Wrapper/V1/AbstractWrapper.php
@@ -51,7 +51,7 @@ abstract class AbstractWrapper implements WrapperInterface
             case 'int':
                 return (int) $xml;
             case 'double':
-                return (double) $xml;
+                return (float) $xml;
             case 'boolean' :
                 return (bool) ((string) $xml);
             case 'datetime':

--- a/src/Justimmo/Model/Wrapper/V1/EmployeeWrapper.php
+++ b/src/Justimmo/Model/Wrapper/V1/EmployeeWrapper.php
@@ -32,6 +32,7 @@ class EmployeeWrapper extends AbstractWrapper
         'ort',
         'url',
         'anrede',
+        'firma',
     );
 
     public function transformSingle($data)
@@ -44,6 +45,14 @@ class EmployeeWrapper extends AbstractWrapper
 
         $mitarbeiter = new Employee();
         $this->map($this->simpleMapping, $xml, $mitarbeiter);
+
+        // the country is delivered as an attribute rather than a text node
+        if (isset($xml->land)) {
+            $attributes = $this->attributesToArray($xml->land);
+            if (array_key_exists('iso_land', $attributes)) {
+                $mitarbeiter->setCountry(trim((string) $attributes['iso_land']));
+            }
+        }
 
         //format used in team calls
         if (isset($xml->bild) && isset($xml->bild->pfad) && (((string) $xml->bild->pfad) != '')) {

--- a/src/Justimmo/Model/Wrapper/V1/EmployeeWrapper.php
+++ b/src/Justimmo/Model/Wrapper/V1/EmployeeWrapper.php
@@ -56,15 +56,15 @@ class EmployeeWrapper extends AbstractWrapper
 
         //format used in team calls
         if (isset($xml->bild) && isset($xml->bild->pfad) && (((string) $xml->bild->pfad) != '')) {
-            $attachment = new Attachment((string) $xml->bild->pfad);
+            $attachment = new Attachment($this->cast($xml->bild->pfad));
             $attachment->setGroup('PROFILBILD');
             if (isset($xml->bild->pfad_medium)) {
-                $attachment->addData('medium', (string) $xml->bild->pfad_medium);
+                $attachment->addData('medium', $this->cast($xml->bild->pfad_medium));
             }
 
             // add all formats
             foreach ($xml->bild->children() as $key => $size) {
-                $attachment->addData((string)$key, (string)$size);
+                $attachment->addData((string) $key, $this->cast($size));
             }
 
             $mitarbeiter->addAttachment($attachment);
@@ -72,19 +72,19 @@ class EmployeeWrapper extends AbstractWrapper
 
         //format used in project and realty calls
         if (isset($xml->bild) && isset($xml->bild->medium) && (((string) $xml->bild->medium) != '')) {
-            $attachment = new Attachment((string) $xml->bild->medium);
-            $attachment->addData('medium', (string) $xml->bild->medium);
+            $attachment = new Attachment($this->cast($xml->bild->medium));
+            $attachment->addData('medium', $this->cast($xml->bild->medium));
             $attachment->setGroup('PROFILBILD');
             if (isset($xml->bild->small)) {
-                $attachment->addData('small', (string) $xml->bild->small);
+                $attachment->addData('small', $this->cast($xml->bild->small));
             }
             if (isset($xml->bild->big)) {
-                $attachment->addData('big', (string) $xml->bild->big);
+                $attachment->addData('big', $this->cast($xml->bild->big));
             }
 
             // add all formats
             foreach ($xml->bild->children() as $key => $size) {
-                $attachment->addData((string)$key, (string)$size);
+                $attachment->addData((string) $key, $this->cast($size));
             }
 
             $mitarbeiter->addAttachment($attachment);

--- a/src/Justimmo/Model/Wrapper/V1/ProjectWrapper.php
+++ b/src/Justimmo/Model/Wrapper/V1/ProjectWrapper.php
@@ -75,7 +75,7 @@ class ProjectWrapper extends AbstractWrapper
         }
 
         if (isset($xml->erstes_bild) && (((string) $xml->erstes_bild) != '')) {
-            $attachment = new Attachment((string) $xml->erstes_bild);
+            $attachment = new Attachment($this->cast($xml->erstes_bild));
             if (isset($xml->erstes_bild_beschreibung) && (((string) $xml->erstes_bild_beschreibung) != '')) {
                 $attachment->setDescription((string) $xml->erstes_bild_beschreibung);
             }

--- a/src/Justimmo/Model/Wrapper/V1/ProjectWrapper.php
+++ b/src/Justimmo/Model/Wrapper/V1/ProjectWrapper.php
@@ -143,7 +143,7 @@ class ProjectWrapper extends AbstractWrapper
             $key = 0;
 
             foreach ($xml->stellplaetze[0] as $stellplaetz) {
-                $garage = new Garage((string) $stellplaetz->art, (string) $stellplaetz->name, (int) $stellplaetz->anzahl, (string) $stellplaetz->vermarktungsart, (double) $stellplaetz->brutto, (double) $stellplaetz->netto, (double) $stellplaetz->ust, (string) $stellplaetz->ust_typ, (double) $stellplaetz->ust_wert);
+                $garage = new Garage((string) $stellplaetz->art, (string) $stellplaetz->name, (int) $stellplaetz->anzahl, (string) $stellplaetz->vermarktungsart, (float) $stellplaetz->brutto, (float) $stellplaetz->netto, (float) $stellplaetz->ust, (string) $stellplaetz->ust_typ, (float) $stellplaetz->ust_wert);
 
                 $project->addGarage($key, $garage);
 
@@ -153,8 +153,8 @@ class ProjectWrapper extends AbstractWrapper
 
         if (isset($xml->geokoordinaten)) {
             $coord = $this->attributesToArray($xml->geokoordinaten->attributes());
-            $project->setLatitude((double) $coord['breitengrad']);
-            $project->setLongitude((double) $coord['laengengrad']);
+            $project->setLatitude((float) $coord['breitengrad']);
+            $project->setLongitude((float) $coord['laengengrad']);
         }
 
         if (isset($xml->residential_aggregation_data)) {

--- a/src/Justimmo/Model/Wrapper/V1/RealtyWrapper.php
+++ b/src/Justimmo/Model/Wrapper/V1/RealtyWrapper.php
@@ -287,8 +287,8 @@ class RealtyWrapper extends AbstractWrapper
 
             if (isset($xml->geo->geokoordinaten)) {
                 $coord = $this->attributesToArray($xml->geo->geokoordinaten->attributes());
-                $objekt->setLatitude((double) $coord['breitengrad']);
-                $objekt->setLongitude((double) $coord['laengengrad']);
+                $objekt->setLatitude((float) $coord['breitengrad']);
+                $objekt->setLongitude((float) $coord['laengengrad']);
             }
 
             if (isset($xml->geo->land)) {
@@ -353,7 +353,7 @@ class RealtyWrapper extends AbstractWrapper
             if (isset($xml->preise->zusatzkosten)) {
                 foreach ($xml->preise->zusatzkosten[0] as $key => $zusatzkosten) {
                     $name  = isset($zusatzkosten->name) ? $zusatzkosten->name : $key;
-                    $costs = new AdditionalCosts((string) $name, (double) $zusatzkosten->brutto, (double) $zusatzkosten->netto, (double) $zusatzkosten->ust, (string) $zusatzkosten->ust_typ, (double) $zusatzkosten->ust_berechneter_wert, (double) $zusatzkosten->ust_wert);
+                    $costs = new AdditionalCosts((string) $name, (float) $zusatzkosten->brutto, (float) $zusatzkosten->netto, (float) $zusatzkosten->ust, (string) $zusatzkosten->ust_typ, (float) $zusatzkosten->ust_berechneter_wert, (float) $zusatzkosten->ust_wert);
 
                     if (isset($zusatzkosten->optional)) {
                         $costs->setOptional(filter_var((string) $zusatzkosten->optional, FILTER_VALIDATE_BOOLEAN));
@@ -367,7 +367,7 @@ class RealtyWrapper extends AbstractWrapper
                 $key = 0;
 
                 foreach ($xml->preise->stellplaetze[0] as $stellplaetz) {
-                    $garage = new Garage((string) $stellplaetz->art, (string) $stellplaetz->name, (int) $stellplaetz->anzahl, (string) $stellplaetz->vermarktungsart, (double) $stellplaetz->brutto, (double) $stellplaetz->netto, (double) $stellplaetz->ust, (string) $stellplaetz->ust_typ, (double) $stellplaetz->ust_wert);
+                    $garage = new Garage((string) $stellplaetz->art, (string) $stellplaetz->name, (int) $stellplaetz->anzahl, (string) $stellplaetz->vermarktungsart, (float) $stellplaetz->brutto, (float) $stellplaetz->netto, (float) $stellplaetz->ust, (string) $stellplaetz->ust_typ, (float) $stellplaetz->ust_wert);
 
                     $objekt->addGarage($key, $garage);
 

--- a/src/Justimmo/Model/Wrapper/V1/RealtyWrapper.php
+++ b/src/Justimmo/Model/Wrapper/V1/RealtyWrapper.php
@@ -177,18 +177,18 @@ class RealtyWrapper extends AbstractWrapper
 
         //list object attachment mapping
         if (isset($xml->erstes_bild)) {
-            $attachment = new Attachment((string) $xml->erstes_bild);
+            $attachment = new Attachment($this->cast($xml->erstes_bild));
             if (isset($xml->erstes_bild_beschreibung) && (((string) $xml->erstes_bild_beschreibung) != '')) {
                 $attachment->setDescription((string) $xml->erstes_bild_beschreibung);
             }
             $objekt->addAttachment($attachment);
         }
         if (isset($xml->zweites_bild)) {
-            $attachment = new Attachment((string) $xml->zweites_bild);
+            $attachment = new Attachment($this->cast($xml->zweites_bild));
             if (isset($xml->zweites_bild_beschreibung) && (((string) $xml->zweites_bild_beschreibung) != '')) {
                 $attachment->setDescription((string) $xml->zweites_bild_beschreibung);
             }
-            $objekt->addAttachment(new Attachment((string) $xml->zweites_bild));
+            $objekt->addAttachment(new Attachment($this->cast($xml->zweites_bild)));
         }
 
         //detailed attributes from detail view, OpenImmo

--- a/tests/Justimmo/Tests/Model/AttachmentTest.php
+++ b/tests/Justimmo/Tests/Model/AttachmentTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Justimmo\Tests\Model;
 
+use Justimmo\Exception\AttachmentSizeNotFoundException;
 use Justimmo\Model\Attachment;
 use Justimmo\Tests\TestCase;
 
@@ -20,5 +21,26 @@ class AttachmentTest extends TestCase
         $this->assertEquals('http://files.justimmo.at/public/doc/test.pdf', $attachment->calculateUrl('hq'));
         $this->assertEquals('http://files.justimmo.at/public/doc/test.pdf', $attachment->calculateUrl('default'));
         $this->assertEquals('http://files.justimmo.at/public/doc/test.pdf', $attachment->calculateUrl());
+    }
+
+    public function testGetUrlReturnsTheRequestedSize()
+    {
+        $attachment = new Attachment('http://files.justimmo.at/public/pic/orig/test.jpg');
+        $attachment->mergeData(array('big' => 'http://files.justimmo.at/public/pic/big/test.jpg'));
+
+        $this->assertEquals('http://files.justimmo.at/public/pic/orig/test.jpg', $attachment->getUrl());
+        $this->assertEquals('http://files.justimmo.at/public/pic/big/test.jpg', $attachment->getUrl('big'));
+    }
+
+    public function testGetUrlThrowsForASizeTheApiDidNotReturn()
+    {
+        // Project images are returned with only the original size, so asking for
+        // a larger one used to emit a php warning and return null.
+        $attachment = new Attachment('http://files.justimmo.at/public/pic/orig/test.jpg');
+
+        $this->expectException(AttachmentSizeNotFoundException::class);
+        $this->expectExceptionMessage('does not provide the size "big"');
+
+        $attachment->getUrl('big');
     }
 }

--- a/tests/Justimmo/Tests/Wrapper/V1/AbstractWrapperTrimTest.php
+++ b/tests/Justimmo/Tests/Wrapper/V1/AbstractWrapperTrimTest.php
@@ -54,4 +54,40 @@ XML;
 
         $this->assertEquals('Ein Projekt', $project->getTitle());
     }
+
+    public function testContactPhotoSizesAreUsable()
+    {
+        $wrapper = new ProjectWrapper(new ProjectMapper());
+        $project = $wrapper->transformSingle(<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<justimmo>
+    <projekt>
+        <id>1</id>
+        <kontaktperson>
+            <name>Mustermann</name>
+            <bild>
+                <small>
+                    https://storage.justimmo.at/thumb/abc/small.jpg
+                </small>
+                <medium>
+                    https://storage.justimmo.at/thumb/abc/medium.jpg
+                </medium>
+                <big>
+                    https://storage.justimmo.at/thumb/abc/big.jpg
+                </big>
+            </bild>
+        </kontaktperson>
+    </projekt>
+</justimmo>
+XML
+        );
+
+        $attachments = $project->getContact()->getAttachments();
+        $this->assertCount(1, $attachments);
+
+        foreach (array('small', 'medium', 'big') as $size) {
+            $url = $attachments[0]->getUrl($size);
+            $this->assertNotFalse(filter_var($url, FILTER_VALIDATE_URL), $size . ' must be a usable url');
+        }
+    }
 }

--- a/tests/Justimmo/Tests/Wrapper/V1/AbstractWrapperTrimTest.php
+++ b/tests/Justimmo/Tests/Wrapper/V1/AbstractWrapperTrimTest.php
@@ -1,0 +1,57 @@
+<?php
+namespace Justimmo\Tests\Wrapper\V1;
+
+use Justimmo\Model\Mapper\V1\ProjectMapper;
+use Justimmo\Model\Wrapper\V1\ProjectWrapper;
+use Justimmo\Tests\TestCase;
+
+/**
+ * The api pretty prints some responses, which puts an element's value on its
+ * own indented line and makes that whitespace part of the text node.
+ */
+class AbstractWrapperTrimTest extends TestCase
+{
+    private function prettyPrintedProject()
+    {
+        return <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<justimmo>
+    <projekt>
+        <id>1</id>
+        <titel>
+            Ein Projekt
+        </titel>
+        <bilder>
+            <bild>
+                <titel>bild.jpg</titel>
+                <pfad>
+                    https://storage.justimmo.at/thumb/abc/bild.jpg
+                </pfad>
+            </bild>
+        </bilder>
+    </projekt>
+</justimmo>
+XML;
+    }
+
+    public function testAttachmentUrlsAreUsable()
+    {
+        $wrapper = new ProjectWrapper(new ProjectMapper());
+        $project = $wrapper->transformSingle($this->prettyPrintedProject());
+
+        $attachments = $project->getAttachments();
+        $this->assertCount(1, $attachments);
+
+        $url = $attachments[0]->getUrl();
+        $this->assertEquals('https://storage.justimmo.at/thumb/abc/bild.jpg', $url);
+        $this->assertNotFalse(filter_var($url, FILTER_VALIDATE_URL));
+    }
+
+    public function testScalarValuesAreTrimmed()
+    {
+        $wrapper = new ProjectWrapper(new ProjectMapper());
+        $project = $wrapper->transformSingle($this->prettyPrintedProject());
+
+        $this->assertEquals('Ein Projekt', $project->getTitle());
+    }
+}

--- a/tests/Justimmo/Tests/Wrapper/V1/EmployeeWrapperTest.php
+++ b/tests/Justimmo/Tests/Wrapper/V1/EmployeeWrapperTest.php
@@ -83,4 +83,25 @@ class EmployeeWrapperTest extends TestCase
         $entry = $list[2];
         $this->assertEmpty($entry->getSuffix());
     }
+
+    public function testCompanyAndCountryAreMapped()
+    {
+        $wrapper = new EmployeeWrapper(new EmployeeMapper());
+        $employee = $wrapper->transformSingle(<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<justimmo>
+    <mitarbeiter>
+        <id>1</id>
+        <vorname>Max</vorname>
+        <name>Mustermann</name>
+        <firma>Muster Immobilien GmbH</firma>
+        <land iso_land="AUT"/>
+    </mitarbeiter>
+</justimmo>
+XML
+        );
+
+        $this->assertEquals('Muster Immobilien GmbH', $employee->getCompany());
+        $this->assertEquals('AUT', $employee->getCountry());
+    }
 }


### PR DESCRIPTION
Hi! We are building a WordPress integration on top of the SDK and ran into a handful of things while testing against php 8.5. All four are small and independent, and each commit stands alone — happy to split this into separate PRs if you would rather review them that way.

Tests go from 52 to 58; `vendor/bin/phpstan analyse` reports no errors, including the baseline.

## 1. `(double)` casts raise deprecations on php 8.5

php 8.5 deprecates the non-canonical `(double)` cast. One of the eight occurrences is in `AbstractWrapper::cast()`, so **every** parsed response containing a float-typed field raises `E_DEPRECATED`. On a WordPress site with `WP_DEBUG` enabled that fills the debug log on every api call.

`(float)` is the canonical spelling of the same cast, so behaviour is unchanged. Your CI already runs on 8.5 — it just doesn't fail on deprecations, which is presumably why this went unnoticed.

## 2. Whitespace in text nodes makes attachment urls unusable

Some responses come back pretty printed, which puts an element's value on its own indented line and makes that whitespace part of the text node. The same endpoint is not consistent about it — one `projekt/detail` response returned `<pfad>https://…</pfad>` inline, another returned the url indented on its own line.

The result is that `Attachment::getUrl()` can return a string that fails `filter_var($url, FILTER_VALIDATE_URL)` and breaks a plain `<img src>` or a download, so every consumer has to trim defensively.

Trimming happens in three places, because attachment urls reach the caller by three routes: `cast()`, the raw `(array)` cast of `<daten>`, and the direct `(string)` casts in `EmployeeWrapper` (contact photo sizes) and `RealtyWrapper` / `ProjectWrapper` (`erstes_bild` / `zweites_bild`).

The `boolean` and `datetime` branches of `cast()` benefit too: previously a whitespace-only value was truthy, and `DateTime` would have been handed a blank string instead of the method returning `null`.

## 3. `Attachment::getUrl()` warns for a size the api did not return

`getUrl()` read `$this->data[$size]` unguarded, so asking for a size the api did not deliver emitted `Warning: Undefined array key` and returned `null`. This happens routinely: project images come back with the original size only, while realty attachments carry `small`/`medium`/`big`/`big2`/`fullhd`, so the same call is fine for one attachment and broken for another.

`AttachmentSizeNotFoundException` already exists, is imported in that class, and is documented on `getVideoPosterUrl()` — which delegates to `getUrl()` — so a thrown exception looks like the intended contract that just never got implemented. The message names the sizes that are available and points at `calculateUrl()`.

`getUrl()` without an argument is unaffected, since the constructor always seeds the `orig` key.

## 4. `kontaktperson` loses `firma` and `land`

Both are returned by `projekt/detail` and `objekt/detail` but neither reached `Employee`: `firma` was missing from the wrapper's mapping, and `land` carries its value in an `iso_land` attribute rather than a text node, so the generic element mapping could not pick it up either. Added as `Employee::getCompany()` and `Employee::getCountry()`.

## Two behaviour changes worth your judgement

- **3** turns a warning + `null` into a thrown exception. That is the documented intent, but it is a behaviour change for anyone currently relying on the `null`. `?? null` is a one-line alternative if you would rather not break that.
- **2** trims every string value, not just urls. I think that is right for an xml api, but it is the broadest change here.

I also left `ext-curl` alone: the default transport genuinely needs it, so moving it to `suggest` would break anyone using the SDK as shipped. Related question though — is overriding `JustimmoApi::createRequest()` a supported extension point? We replace the transport with WordPress's http client to get proxy support and the platform's request filters, and it would be good to know we can rely on that.

The changelog entries are under an `Unreleased` heading; rename as you see fit.
